### PR TITLE
Fix common folder not included in built wheel

### DIFF
--- a/src/wktplot/__init__.py
+++ b/src/wktplot/__init__.py
@@ -1,3 +1,3 @@
 from .plots.standard import WKTPlot  # noqa: F401
 
-__version__ = "2.3.0"
+__version__ = "2.3.1"

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import os
 
 
-SOURCE_PATH = Path(__file__).parent / ".." / ".." / "src" / "wktplot"
+SOURCE_PATH = (Path(__file__).parent / ".." / ".." / "src" / "wktplot").resolve()
 
 
 class TestFolderStructure:
@@ -12,4 +12,4 @@ class TestFolderStructure:
             directory = Path(directory)
             if directory.name == "__pycache__":
                 continue
-            assert "__init__.py" in files, f"Folder missing __init__.py file, {directory.resolve()}"
+            assert "__init__.py" in files, f"Folder missing __init__.py file, {directory}"

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import os
+
+
+SOURCE_PATH = Path(__file__).parent / ".." / ".." / "src" / "wktplot"
+
+
+class TestFolderStructure:
+    def test_source_structure_has_init_files(self):
+        assert SOURCE_PATH.is_dir()
+        for directory, _, files in os.walk(SOURCE_PATH):
+            directory = Path(directory)
+            if directory.name == "__pycache__":
+                continue
+            assert "__init__.py" in files, f"Folder missing __init__.py file, {directory.resolve()}"


### PR DESCRIPTION
# Pull Request

## Description
Add `__init__.py` file to `common` folder so it's found by setuptools when the wheel is being built.

## Type of Change

Check the type of change this PR addresses:

- [x] Bug
- [ ] Feature
- [ ] Documentation

## Backwards Compatibility

- [x] This change breaks backwards compatibility
- [ ] I have bumped the major version

## Documentation

- [ ] This change requires a documentation update

## Tests

- [ ] This change requires new tests

Add a screenshot or paste your local test results below:
![image](https://user-images.githubusercontent.com/16249360/184706481-7bdd6019-a61f-4cfd-bc0d-010dcb28a8cc.png)


## Misc

- [x] I have followed the guidelines for contribution
- [x] I have ensured there aren't other open Pull Requests for the same update/change

## Thanks

Thank you for your interest and taking the time to contribute!
